### PR TITLE
Fixes an issue where logical operators would match as part of a variable

### DIFF
--- a/grammars/rego.cson
+++ b/grammars/rego.cson
@@ -81,7 +81,7 @@ patterns: [
     name: "keyword.operator.definition.rego"
   }
   {
-    match: "(as|default|else|false|not|null|true|with)"
+    match: "(\\bas\\b|\\bdefault\\b|\\belse\\b|\\bfalse\\b|\\bnot\\b|\\bnull\\b|\\btrue\\b|\\bwith\\b)"
     name: "keyword.operator.logical.rego"
   }
   {


### PR DESCRIPTION
This fixes an issue where the `as` in the variable `asset` or similar would be highlighted since there was no break `\b` character as part of the matcher.